### PR TITLE
14077-fix-oom-kill-of-osmium-process-for-big-extract

### DIFF
--- a/scripts/osm_data_import.sh
+++ b/scripts/osm_data_import.sh
@@ -7,5 +7,5 @@ base_name=$(basename "$1")
 prefix_name="osm_${base_name%.*}"
 input="data/in/mapaction/${base_name/json/pbf}"
 psql -1 -f tables/osm_data_table.sql -v tablename=${prefix_name}
-osmium export -c static_data/mapaction_osmium.config.json -f pg $input -v --progress | psql -c "copy $prefix_name from stdin;"
+osmium export -c static_data/mapaction_osmium.config.json -f pg $input -v --progress -e -i dense_mmap_array | psql -c "copy $prefix_name from stdin;"
 psql -1 -c "create index on $prefix_name using gin (tags);"


### PR DESCRIPTION
with this fix osmium does not get killed with OOM error for big extracts