### PR TITLE
14493 prevent last_modified.txt files from being included in complete…

### DIFF
--- a/scripts/download_hdx_admin_boundaries.sh
+++ b/scripts/download_hdx_admin_boundaries.sh
@@ -35,7 +35,7 @@ if wget -O $ckan_package_json_path "https://data.humdata.org/api/3/action/packag
 
         if [ $file_extension = "shp" ]; then
             ogr2ogr "data/out/country_extractions/"$country_code"/202_admn/"$country_code"_admn_ad0_py_s4_unocha_pp_"$display_name".geojson" $filename
-            echo "$last_modified" > "data/out/country_extractions/"$country_code"/202_admn/"$country_code"_admn_ad0_py_s4_unocha_pp_"$display_name"_last_modified.txt"
+            echo "$last_modified" > "data/out/country_extractions/"$country_code"/202_admn/"$country_code"_admn_ad0_py_s4_unocha_pp_"$display_name".last_modified.txt"
         fi
     done
 
@@ -48,7 +48,7 @@ if wget -O $ckan_package_json_path "https://data.humdata.org/api/3/action/packag
 
         if [ $file_extension = "shp" ]; then
             ogr2ogr "data/out/country_extractions/"$country_code"/202_admn/"$country_code"_admn_ad1_py_s4_unocha_pp_"$display_name".geojson" $filename
-            echo "$last_modified" > "data/out/country_extractions/"$country_code"/202_admn/"$country_code"_admn_ad1_py_s4_unocha_pp_"$display_name"_last_modified.txt"
+            echo "$last_modified" > "data/out/country_extractions/"$country_code"/202_admn/"$country_code"_admn_ad1_py_s4_unocha_pp_"$display_name".last_modified.txt"
         fi
     done
 
@@ -61,7 +61,7 @@ if wget -O $ckan_package_json_path "https://data.humdata.org/api/3/action/packag
 
         if [ $file_extension = "shp" ]; then
             ogr2ogr "data/out/country_extractions/"$country_code"/202_admn/"$country_code"_admn_ad2_py_s4_unocha_pp_"$display_name".geojson" $filename
-            echo "$last_modified" > "data/out/country_extractions/"$country_code"/202_admn/"$country_code"_admn_ad2_py_s4_unocha_pp_"$display_name"_last_modified.txt"
+            echo "$last_modified" > "data/out/country_extractions/"$country_code"/202_admn/"$country_code"_admn_ad2_py_s4_unocha_pp_"$display_name".last_modified.txt"
         fi
     done
 fi

--- a/scripts/mapaction_export.sh
+++ b/scripts/mapaction_export.sh
@@ -36,7 +36,7 @@ do
     ogr2ogr -f "ESRI Shapefile" $OUTDIR/$dir_name/$output.shp PG:"dbname=$PGDATABASE" -sql "${sql}" -lco ENCODING=UTF8
     rm -f $OUTDIR/$dir_name/$output.geojson
     ogr2ogr -f "GeoJSON" $OUTDIR/$dir_name/$output.geojson PG:"dbname=$PGDATABASE" -sql "${sql}" -lco WRITE_NAME=NO
-    cp data/in/mapaction/osm_last_modified_date $OUTDIR/$dir_name/$output"_last_modified.txt"
+    cp data/in/mapaction/osm_last_modified_date $OUTDIR/$dir_name/$output".last_modified.txt"
 done < <( psql -t -A -F , -c "SELECT country_code, ma_category, ma_theme, feature_type, ma_tag, dir_name FROM ${mapaction_table_name}, mapaction_directories where dir_name ~* ma_category group by 1,2,3,4,5,6")
 
 # delete empty directories if exists

--- a/scripts/mapaction_upload_dataset.sh
+++ b/scripts/mapaction_upload_dataset.sh
@@ -9,7 +9,7 @@ output_shp_zip_path="data/out/country_extractions/$(basename $shp_path).zip"
 zip -r -j $output_shp_zip_path "${shp_path%.*}"* -x "*.geojson"
 
 output_geojson_zip_path="data/out/country_extractions/$(basename $geojson_path).zip"
-zip -r -j $output_geojson_zip_path "${shp_path%.*}.geojson" "${shp_path%.*}_last_modified.txt"
+zip -r -j $output_geojson_zip_path "${shp_path%.*}.geojson" "${shp_path%.*}.last_modified.txt"
 
 echo "output_shp_zip_path $output_shp_zip_path"
 echo "output_geojson_zip_path $output_geojson_zip_path"


### PR DESCRIPTION
…ness report

script that builds completeness report lists all files with unique names in directory with a dataset. since suffix part of filename that contains extension is ignored while comparing filenames _last_modified.txt can be changed to .last_modified.txt and it should prevent last_modified files from being included in completeness report.