### PR TITLE
14440 dataset metadata should be included into CMF active data folder to be available for the CMF Active Data users

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ data/out/datasets_all: data/out/country_extractions/ne_10m_lakes data/out/countr
 	touch $@
 
 data/out/datasets_ckan_descriptions: data/out/datasets_all | data/out ## create json files with metadata for CKAN upload per dataset
-	find data/out/country_extractions/ -regex ".*\.\(shp\|geojson\|tif\|csv\)" | parallel 'bash scripts/mapaction_build_dataset_description.sh {}'
+	find data/out/country_extractions/ -mindepth 3 -regex ".*\.\(shp\|geojson\|tif\|csv\)" | parallel 'bash scripts/mapaction_build_dataset_description.sh {}'
 	touch $@
 
 data/out/cmf_metadata_list_all: data/out/datasets_ckan_descriptions | data/out ## create csv file with metadata per country

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ data/out/datasets_all: data/out/country_extractions/ne_10m_lakes data/out/countr
 	touch $@
 
 data/out/datasets_ckan_descriptions: data/out/datasets_all | data/out ## create json files with metadata for CKAN upload per dataset
-	find data/out/country_extractions/ -regex ".*\.\(geojson\|tif\|csv\)" | parallel 'mapaction_build_dataset_description.sh {}'
+	find data/out/country_extractions/ -regex ".*\.\(shp\|geojson\|tif\|csv\)" | parallel 'mapaction_build_dataset_description.sh {}'
 	touch $@
 
 data/out/cmf_metadata_list_all: data/out/datasets_ckan_descriptions | data/out ## create csv file with metadata per country

--- a/Makefile
+++ b/Makefile
@@ -186,11 +186,12 @@ osmium_extract_config.json: ## generate config for osmium-extract
 data/mid/mapaction: | data/mid ## create directory data/mid/mapaction
 	mkdir -p $@
 
-data/in/mapaction/osm_last_modified_date: data/planet-latest-updated.osm.pbf | data/mid/mapaction ## get osm pbf last modified date
-	osmium fileinfo -e -g data.timestamp.last data/planet-latest-updated.osm.pbf > $@
-
 data/in/mapaction/per_country_pbf: data/planet-latest-updated.osm.pbf osmium_extract_config.json | data/mid/mapaction ## create per-country extracts pbf files from planet.pbf
 	osmium extract --config osmium_extract_config.json --overwrite data/planet-latest-updated.osm.pbf
+	touch $@
+
+data/in/mapaction/osm_last_modified_date: data/in/mapaction/per_country_pbf | data/mid/mapaction ## get osm pbf last modified date
+	ls data/mid/mapaction/*.pbf | parallel 'osmium fileinfo -e -g data.timestamp.last {} > {}.last_modified.txt'
 	touch $@
 
 db/table/osm_data_import: data/in/mapaction/per_country_pbf | db/table ## Create and populate osm_[] tables in db

--- a/Makefile
+++ b/Makefile
@@ -166,17 +166,29 @@ data/out/country_extractions/global_power_plant_database: data/in/mapaction/glob
 data/out/cmf: | data/out ## create directory for CMFs
 	mkdir -p $@
 
-data/out/upload_datasets_all: data/out/country_extractions/ne_10m_lakes data/out/country_extractions/ourairports data/out/country_extractions/worldports data/out/country_extractions/wfp_railroads data/out/country_extractions/global_power_plant_database data/out/country_extractions/ne_10m_rivers_lake_centerlines data/out/country_extractions/ne_10m_populated_places data/out/country_extractions/ne_10m_roads data/out/country_extractions/healthsites data/out/country_extractions/ocha_admin_boundaries data/out/mapaction_export data/out/country_extractions/worldpop1km data/out/country_extractions/worldpop100m data/out/country_extractions/elevation | data/out ## upload datasets in CKAN
+data/out/datasets_all: data/out/country_extractions/ne_10m_lakes data/out/country_extractions/ourairports data/out/country_extractions/worldports data/out/country_extractions/wfp_railroads data/out/country_extractions/global_power_plant_database data/out/country_extractions/ne_10m_rivers_lake_centerlines data/out/country_extractions/ne_10m_populated_places data/out/country_extractions/ne_10m_roads data/out/country_extractions/healthsites data/out/country_extractions/ocha_admin_boundaries data/out/mapaction_export data/out/country_extractions/worldpop1km data/out/country_extractions/worldpop100m data/out/country_extractions/elevation  | data/out ## Milestone: all the datasets have been prepared
+	echo "all the datasets prepared"
+	touch $@
+
+data/out/datasets_ckan_descriptions: data/out/datasets_all | data/out ## create json files with metadata for CKAN upload per dataset
+	echo "TODO: move creation of dataset CKAN descriptions here"
+	touch $@
+
+data/out/cmf_metadata_list_all: data/out/datasets_ckan_descriptions | data/out ## create csv file with metadata per country
+	echo "TODO: create csv file with metadata per country"
+	touch $@
+
+data/out/upload_datasets_all: data/out/datasets_ckan_descriptions | data/out ## upload datasets in CKAN
 	find data/out/country_extractions/ -name "*.shp" | parallel 'bash scripts/mapaction_upload_dataset.sh {} shp'
 	find data/out/country_extractions/ -name "*.geojson" | parallel 'bash scripts/mapaction_upload_dataset.sh {} geojson'
 	find data/out/country_extractions/ -name "*.tif" | parallel 'bash scripts/mapaction_upload_dataset.sh {} tif'
 	touch $@
 
-data/out/upload_cmf_all: data/out/country_extractions/ne_10m_lakes data/out/country_extractions/ourairports data/out/country_extractions/worldports data/out/country_extractions/wfp_railroads data/out/country_extractions/global_power_plant_database data/out/country_extractions/ne_10m_rivers_lake_centerlines data/out/country_extractions/ne_10m_populated_places data/out/country_extractions/ne_10m_roads data/out/country_extractions/healthsites data/out/country_extractions/ocha_admin_boundaries data/out/mapaction_export data/out/country_extractions/worldpop1km data/out/country_extractions/worldpop100m data/out/country_extractions/elevation | data/out/cmf ## upload CMFs in CKAN
+data/out/upload_cmf_all: data/out/cmf_metadata_list_all | data/out/cmf ## upload CMFs in CKAN
 	find data/out/country_extractions/ -mindepth 1 -maxdepth 1 -type d | parallel 'bash scripts/mapaction_upload_cmf.sh {}'
 	touch $@
 
-create_completeness_report: data/out/upload_cmf_all | data/out/country_extractions ## create separate report for each country directory
+create_completeness_report: data/out/upload_cmf_all | data/out/country_extractions ## create completeness report for each country
 	find data/out/country_extractions/ -mindepth 1 -maxdepth 1 -type d | parallel 'python scripts/create_completeness_report.py {}'
 	touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ data/out/datasets_ckan_descriptions: data/out/datasets_all | data/out ## create 
 	touch $@
 
 data/out/cmf_metadata_list_all: data/out/datasets_ckan_descriptions | data/out ## create csv file with metadata per country
-	echo "TODO: create csv file with metadata per country"
+	find data/out/country_extractions/ -mindepth 1 -maxdepth 1 -type d | parallel 'python scripts/build_metadata_list.py {}'
 	touch $@
 
 data/out/upload_datasets_all: data/out/datasets_ckan_descriptions | data/out ## upload datasets in CKAN

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ data/out/datasets_all: data/out/country_extractions/ne_10m_lakes data/out/countr
 	touch $@
 
 data/out/datasets_ckan_descriptions: data/out/datasets_all | data/out ## create json files with metadata for CKAN upload per dataset
-	find data/out/country_extractions/ -regex ".*\.\(shp\|geojson\|tif\|csv\)" | parallel 'mapaction_build_dataset_description.sh {}'
+	find data/out/country_extractions/ -regex ".*\.\(shp\|geojson\|tif\|csv\)" | parallel 'bash scripts/mapaction_build_dataset_description.sh {}'
 	touch $@
 
 data/out/cmf_metadata_list_all: data/out/datasets_ckan_descriptions | data/out ## create csv file with metadata per country

--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ data/out/datasets_all: data/out/country_extractions/ne_10m_lakes data/out/countr
 	touch $@
 
 data/out/datasets_ckan_descriptions: data/out/datasets_all | data/out ## create json files with metadata for CKAN upload per dataset
-	echo "TODO: move creation of dataset CKAN descriptions here"
+	find data/out/country_extractions/ -regex ".*\.\(geojson\|tif\|csv\)" | parallel 'mapaction_build_dataset_description.sh {}'
 	touch $@
 
 data/out/cmf_metadata_list_all: data/out/datasets_ckan_descriptions | data/out ## create csv file with metadata per country

--- a/scripts/build_ckan_dataset_description.py
+++ b/scripts/build_ckan_dataset_description.py
@@ -35,7 +35,7 @@ def determine_dataset_dates(source, geoextent, geocint_folder, dataset_filename)
 
     # download date -- when the source is downloaded. We will take time stamp of the downloaded file.
     if source == 'worldpop':
-        download_timestamp = DatasetCreationTime #worldpop is downladed directly to the out folder.
+        download_timestamp = creation_timestamp #worldpop is downladed directly to the out folder.
     elif source == 'unocha':
         #hdx admin boundaries are downloaded per country.
         source_path=os.path.join(os.path.join(geocint_folder,SourceFiles[source]), geoextent)

--- a/scripts/build_ckan_dataset_description.py
+++ b/scripts/build_ckan_dataset_description.py
@@ -16,6 +16,7 @@ SourceFiles ={
     'osm': "data/planet-latest-updated.osm.pbf",
     'ourairports': "data/in/mapaction/ourairports/airports.csv",
     'srtm': "data/in/srtm30m/_list_files.txt",
+    'gmted2010': "data/in/gmted250m/gmted250m.zip",
     'wfp': "data/in/mapaction/wfp_railroads.zip",
     'worldports': "data/in/mapaction/worldports/worldports.csv",
     'unocha': "data/in/mapaction/ocha_admin_boundaries"
@@ -47,7 +48,7 @@ def determine_dataset_dates(source, geoextent, geocint_folder, dataset_filename)
                 os.path.getmtime(os.path.join(geocint_folder, SourceFiles[source])))
         else:
             download_timestamp = ""
-            sys.stderr.write("WARNING: download date of "+source+" source cannot be obtained. No origin file specified for this source \n")
+            sys.stderr.write("WARNING: download date of "+source+" source cannot be obtained. No origin file specified for this source. \n")
 
     # reference date is when the orgin was lastly modified.
     # now let's obtain it from .last_modified.txt file.

--- a/scripts/build_ckan_dataset_description.py
+++ b/scripts/build_ckan_dataset_description.py
@@ -47,7 +47,7 @@ def determine_dataset_dates(source, geoextent, geocint_folder, dataset_filename)
                 os.path.getmtime(os.path.join(geocint_folder, SourceFiles[source])))
         else:
             download_timestamp = ""
-            sys.stderr.write("download date of "+source+" source cannot be obtained. No origin file specified for this source \n")
+            sys.stderr.write("WARNING: download date of "+source+" source cannot be obtained. No origin file specified for this source \n")
 
     # reference date is when the orgin was lastly modified.
     # now let's obtain it from .last_modified.txt file.
@@ -63,7 +63,7 @@ def determine_dataset_dates(source, geoextent, geocint_folder, dataset_filename)
         fo1.close
     else:
         reference_timestamp = ""
-        sys.stderr.write("unable to determine reference date for "+dataset_filename)
+        sys.stderr.write("WARNING: unable to determine reference date for "+dataset_filename+"\n")
 
     if download_timestamp=="":
         download_timestamp="unknown"

--- a/scripts/build_ckan_dataset_description.py
+++ b/scripts/build_ckan_dataset_description.py
@@ -50,21 +50,30 @@ def determine_dataset_dates(source, geoextent, geocint_folder, dataset_filename)
             download_timestamp = ""
             sys.stderr.write("WARNING: download date of "+source+" source cannot be obtained. No origin file specified for this source. \n")
 
-    # reference date is when the orgin was lastly modified.
-    # now let's obtain it from .last_modified.txt file.
-    if source == "osm":
-        last_modified_file_name = os.path.join(geocint_folder, "data/mid/mapaction/"+ geoextent+'.pbf'+ ".last_modified.txt")
+    if source == "srtm" or "gmted2010":
+        # for some sources reference date is known and will not change
+        # space shuttle is no longer in service
+        reference_timestamp = "2010-01-01T00:00:00Z"
     else:
-        last_modified_file_name = ""
+        # reference date is when the orgin was lastly modified.
+        # now let's obtain it from .last_modified.txt file.
+        last_modified_file_name = os.path.join(geocint_folder,
+                                               os.path.splitext(dataset_filename)[0] + ".last_modified.txt")
 
-    if os.path.exists(last_modified_file_name):
-        fo1 = open(last_modified_file_name, 'r', encoding="utf-8")
-        reference_timestamp = fo1.read()
-        reference_timestamp = reference_timestamp.replace("\n",'')
-        fo1.close
-    else:
-        reference_timestamp = ""
-        sys.stderr.write("WARNING: unable to determine reference date for "+dataset_filename+"\n")
+        if not os.path.exists(last_modified_file_name):
+            if source == "osm":
+                last_modified_file_name = os.path.join(geocint_folder, "data/mid/mapaction/"+ geoextent+'.pbf'+ ".last_modified.txt")
+            else:
+                last_modified_file_name = ""
+
+        if os.path.exists(last_modified_file_name):
+            fo1 = open(last_modified_file_name, 'r', encoding="utf-8")
+            reference_timestamp = fo1.read()
+            reference_timestamp = reference_timestamp.replace("\n",'')
+            fo1.close
+        else:
+            reference_timestamp = ""
+            sys.stderr.write("WARNING: unable to determine reference date for "+dataset_filename+"\n")
 
     if download_timestamp=="":
         download_timestamp="unknown"

--- a/scripts/build_metadata_list.py
+++ b/scripts/build_metadata_list.py
@@ -1,0 +1,110 @@
+#
+# this script creates "metadata list", i.e a list of datasets with appropriate attributes,
+# which should be included into CMF Active Data archive
+#
+import json
+import sys
+import os
+import pathlib
+import datetime
+from ma_dictionaries import FeatureSource
+from ma_dictionaries import FeatureCategoryCodes
+
+
+def get_datasets_filenames_datetime(geoextent, files_folder):
+    datasets = []
+    modifiedTimes = []
+    for (root, dirs, files) in os.walk(files_folder, topdown=True):
+        for file in files:
+            modifiedTime = datetime.datetime.utcfromtimestamp(os.path.getmtime(root + "/" + file))
+            if (file[0:3] == geoextent) or (file[0:3] == 'reg'):
+                dataset_name = file.split('.')[0]
+                if datasets.count(dataset_name) == 0:
+                    datasets.append(dataset_name)
+                    # data size
+                    modifiedTimes.append(modifiedTime.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    # return data name and size
+    return datasets, modifiedTimes
+
+
+def get_extras_value(data,key):
+    for item in data['extras']:
+        if item['key'] == key:
+            return item['value']
+    return ""
+
+def create_csv(output_file_name,geoextent, datasets):
+
+    fo = open(output_file_name, 'w', encoding="utf-8")
+    fo.write('Dataset Name' + ',')
+    fo.write('Folder' + ',')
+    fo.write('Title' + ',')
+    fo.write('Source' + ',')  # ['source']
+    fo.write('Source Url,')
+    fo.write('License,')
+    fo.write('File Creation Date,')
+    fo.write('Download Date,')
+    fo.write('Reference Date')
+    fo.write('\n')
+
+    GEOCINT_WORK_DIRECTORY = os.environ['GEOCINT_WORK_DIRECTORY']
+    ckan_json_folder = os.path.join(GEOCINT_WORK_DIRECTORY,"geocint/data/out/country_extractions")
+
+    for dataset_name in datasets[0]:
+
+        if ((dataset_name[0:3] == geoextent) or (dataset_name[0:3] == 'reg')):
+            codes = dataset_name.split("_", 7)
+            # for some reason, _ckan.json files inculde dataset extension.
+            # we should guess it from geometry type
+            Extentions = {"pt": ".geojson", "ln": ".geojson", "py": ".geojson", "ras": ".tif", ".tab": ".csv"}
+
+            file_extension = Extentions[codes[3]]
+
+            f = open(os.path.join(ckan_json_folder,dataset_name+file_extension+'_ckan.json'))
+            data = json.load(f)
+            source = get_extras_value(data, "source")
+            folder_name = FeatureCategoryCodes[get_extras_value(data, "category")] + '_' + get_extras_value(data, "category")
+
+            # dataset creation date is when dataset file was created
+            creation_timestamp = get_extras_value(data, "creation_date").replace("T"," ").replace("Z","")
+            download_timestamp = get_extras_value(data, "download_date").replace("T"," ").replace("Z","")
+            reference_timestamp = get_extras_value(data, "reference_date").replace("T"," ").replace("Z","")
+
+            fo.write(dataset_name + ',')
+
+            fo.write(folder_name + ',')  # ['source']
+            fo.write(data['title'] + ',')
+            # fo.write('"'+data['notes']+ '", ')
+
+            fo.write(FeatureSource[source] + ',')  # ['source']
+
+            fo.write(data['url'] + ',')
+            fo.write(data.get('license_id', '') + ',')
+
+            fo.write(creation_timestamp +',')
+            if download_timestamp != "unknown":
+                fo.write(download_timestamp+',')
+            else:
+                fo.write(",")
+
+            if reference_timestamp != "unknown":
+                fo.write(reference_timestamp+',')
+
+            fo.write('\n')
+            f.close()
+
+    fo.close()
+
+
+def main():
+    # input from bash find command
+    # example: data/out/country_extractions/tza
+    country_data_folder = sys.argv[1]
+    output_file_name = sys.argv[2]
+    country_code = os.path.basename(country_data_folder)
+    files = get_datasets_filenames_datetime(country_code, country_data_folder)
+    create_csv(output_file_name,country_code, files)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/build_metadata_list.py
+++ b/scripts/build_metadata_list.py
@@ -100,7 +100,14 @@ def main():
     # input from bash find command
     # example: data/out/country_extractions/tza
     country_data_folder = sys.argv[1]
-    output_file_name = sys.argv[2]
+
+    # optional output file name
+    #specify it if you need to test this script separately
+    if len(sys.argv)>2:
+        output_file_name = sys.argv[2]
+    else:
+        output_file_name = os.path.join(country_data_folder,"dataset_metadata.csv")
+
     country_code = os.path.basename(country_data_folder)
     files = get_datasets_filenames_datetime(country_code, country_data_folder)
     create_csv(output_file_name,country_code, files)

--- a/scripts/ma_dictionaries.py
+++ b/scripts/ma_dictionaries.py
@@ -333,6 +333,43 @@ FeatureCategory = \
         "wash": "Water Sanitation and Hygiene"
     }
 
+FeatureCategoryCodes = {
+    "3www": "201",
+    "admn": "202",
+    "affd": "203",
+    "agri": "204",
+    "assm": "205",
+    "bldg": "205",
+    "carto": "207",
+    "cash": "208",
+    "cccm": "209",
+    "educ": "210",
+    "elev": "211",
+    "envi": "212",
+    "evnt": "213",
+    "fsec": "214",
+    "heal": "215",
+    "hazd": "216",
+    "imgy": "217",
+    "land": "218",
+    "logs": "219",
+    "nutr": "220",
+    "phys": "221",
+    "pois": "222",
+    "popu": "223",
+    "prot": "224",
+    "rcvy": "225",
+    "scan": "226",
+    "scty": "227",
+    "shel": "228",
+    "stle": "229",
+    "sar": "230",
+    "telc": "231",
+    "tran": "232",
+    "util": "233",
+    "wash": "234",
+    "uxo": "235"}
+
 FeatureSource = {
     "alertnet": "Alertnet",
     "amb": "Ambulance Service",

--- a/scripts/mapaction_build_dataset_description.sh
+++ b/scripts/mapaction_build_dataset_description.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# this script takes as input path to the file (shp, geojson or tif) 
+# and creates _ckan.json file, which is used later in the process
+
+set -e
+
+filepath=$1
+
+ckan_dataset_description_json_path="data/out/country_extractions/$(basename $filepath)_ckan.json"
+python scripts/build_ckan_dataset_description.py $filepath > $ckan_dataset_description_json_path

--- a/scripts/mapaction_export.sh
+++ b/scripts/mapaction_export.sh
@@ -36,7 +36,6 @@ do
     ogr2ogr -f "ESRI Shapefile" $OUTDIR/$dir_name/$output.shp PG:"dbname=$PGDATABASE" -sql "${sql}" -lco ENCODING=UTF8
     rm -f $OUTDIR/$dir_name/$output.geojson
     ogr2ogr -f "GeoJSON" $OUTDIR/$dir_name/$output.geojson PG:"dbname=$PGDATABASE" -sql "${sql}" -lco WRITE_NAME=NO
-    cp data/in/mapaction/osm_last_modified_date $OUTDIR/$dir_name/$output".last_modified.txt"
 done < <( psql -t -A -F , -c "SELECT country_code, ma_category, ma_theme, feature_type, ma_tag, dir_name FROM ${mapaction_table_name}, mapaction_directories where dir_name ~* ma_category group by 1,2,3,4,5,6")
 
 # delete empty directories if exists

--- a/scripts/mapaction_upload_cmf.sh
+++ b/scripts/mapaction_upload_cmf.sh
@@ -13,7 +13,7 @@ echo "country_extraction_path $country_extraction_path"
 echo "country_code $country_code"
 
 (cd $country_extraction_path; zip -r "../../cmf/$country_code""_active_data_shp.zip" . -x \*.geojson)
-(cd $country_extraction_path; zip -r "../../cmf/$country_code""_active_data_geojson.zip" . -i \*.geojson \*.txt \*.tif)
+(cd $country_extraction_path; zip -r "../../cmf/$country_code""_active_data_geojson.zip" . -i \*.geojson \*.txt \*.tif \*.csv)
 
 # CKAN_DATA_S3_URL=s3://geodata-eu-central-1-kontur-public/mapaction_dataset/
 aws s3 cp "data/out/cmf/$country_code""_active_data_shp.zip" $CKAN_DATA_S3_URL$country_code"_active_data_shp.zip" --acl public-read

--- a/scripts/mapaction_upload_dataset.sh
+++ b/scripts/mapaction_upload_dataset.sh
@@ -24,8 +24,6 @@ fi
 
 ckan_dataset_description_json_path="data/out/country_extractions/$(basename $filepath)_ckan.json"
 
-python scripts/build_ckan_dataset_description.py $filepath > $ckan_dataset_description_json_path
-
 aws s3 cp $output_zip_path $CKAN_DATA_S3_URL$(basename $filepath).zip --acl public-read
 
 set +e


### PR DESCRIPTION
The following has been fixed:
* Dataset creation date, download date and reference date are included as attributes into dataset description on CKAN
* Reference Date is available for OSM based datasets, for COD boundaries and for SRTM/GMTED2010 datasets
* dataset_metadad.csv with dataset descriptions file is included into CMF active data  archive